### PR TITLE
fix issue #27 and #15

### DIFF
--- a/Ahk2Exe.ahk
+++ b/Ahk2Exe.ahk
@@ -257,7 +257,7 @@ CLIMode := true
 return
 
 BadParams:
-Util_Info("Command Line Parameters:`n`n" A_ScriptName " /in infile.ahk [/out outfile.exe] [/icon iconfile.ico] [/bin AutoHotkeySC.bin]")
+Util_Info("Command Line Parameters:`n`n" A_ScriptName " /in infile.ahk [/out outfile.exe] [/icon iconfile.ico] [/bin AutoHotkeySC.bin] [/mpress 1 (true) or 0 (false)]")
 ExitApp
 
 _ProcessIn:

--- a/ScriptParser.ahk
+++ b/ScriptParser.ahk
@@ -90,7 +90,7 @@ PreprocessScript(ByRef ScriptText, AhkScript, ExtraFiles, FileList="", FirstScri
 				}
 			}else if !contSection && tline ~= "i)^FileInstall[, \t]"
 			{
-				if tline ~= "^\w+\s+(:=|+=|-=|\*=|/=|//=|\.=|\|=|&=|\^=|>>=|<<=)"
+				if tline ~= "^\w+\s+(:=|\+=|-=|\*=|/=|//=|\.=|\|=|&=|\^=|>>=|<<=)"
 					continue ; This is an assignment!
 				if !RegExMatch(tline, "i)^FileInstall[ \t]*[, \t][ \t]*([^,]+?)[ \t]*(,|$)", o) || o1 ~= "[^``]%" ; TODO: implement `, detection
 					Util_Error("Error: Invalid ""FileInstall"" syntax found. Note that the first parameter must not be specified using a continuation section.")


### PR DESCRIPTION
From issue #27 

In ScriptParser.ahk line 93
if tline ~= "^\w+\s+(:=|+=|-=|*=|/=|//=|.=||=|&=|^=|>>=|<<=)"
should be:
if tline ~= "^\w+\s+(:=|\+=|-=|*=|/=|//=|.=||=|&=|^=|>>=|<<=)"